### PR TITLE
Fix CI: update Actions to v4, fix cache paths, add Rust job

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,7 +6,35 @@ on:
     branches: [main]
 
 jobs:
-  build:
+  rust:
+    strategy:
+      matrix:
+        os: [ubuntu-24.04, macos-15]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Cache Cargo build files
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: >-
+            ${{ runner.os }}-cargo-${{
+            hashFiles('Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo
+
+      - name: Clippy
+        run: cargo clippy -- -D warnings
+
+      - name: Test
+        run: cargo test
+
+  haskell:
     strategy:
       matrix:
         os: [ubuntu-24.04, macos-15]
@@ -16,7 +44,7 @@ jobs:
         working-directory: ./haskell
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Stack
         uses: haskell-actions/setup@v2
@@ -25,14 +53,14 @@ jobs:
           stack-no-global: true
 
       - name: Cache Stack build files
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.stack
-            .stack-work
+            haskell/.stack-work
           key: >-
             ${{ runner.os }}-stack-${{
-            hashFiles('stack.yaml.lock', 'package.yaml') }}
+            hashFiles('haskell/stack.yaml.lock', 'haskell/package.yaml') }}
           restore-keys: |
             ${{runner.os}}-stack
 
@@ -43,7 +71,7 @@ jobs:
         run: stack install
 
       - name: Upload ${{ runner.os }} Release
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           path: ~/.local/bin/haskell-template
           name: haskell-template_${{ runner.os }}_${{ runner.arch }}


### PR DESCRIPTION
- Update checkout, cache, and upload-artifact from v3 to v4
  (v3 uses Node.js 16 which is sunset and fails on ubuntu-24.04)
- Fix cache paths for .stack-work and hashFiles to include
  haskell/ prefix (actions/cache doesn't respect working-directory)
- Add Rust CI job with clippy and test steps
- Rename Haskell job from generic "build" to "haskell"

https://claude.ai/code/session_01SuwuVYngdqxUX98EL7MuJB